### PR TITLE
Amended AudioTrack exception handling

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/audio/AudioTrack.java
+++ b/library/src/main/java/com/google/android/exoplayer/audio/AudioTrack.java
@@ -1280,8 +1280,8 @@ public final class AudioTrack {
       this.getLatencyMethod = getLatencyMethod;
       try {
         getTimestamp = AudioTrack.class.getMethod("getTimestamp", AudioTimestamp.class);
-      } catch (Exception e) {
-        // There's no guarantee this method exists. Do nothing.
+      } catch (Throwable e) {
+        // There's no guarantee this method or class exists. Do nothing.
         log.w("getTimestamp method not found");
       }
     }


### PR DESCRIPTION
Former handling around testing whether the method exists failed to handle cases where the AudioTimestamp class failed to exist (prior to API level 19).
