### PR TITLE
Worked around build failure on jitpack.

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer2/audio/AudioTrack.java
+++ b/library/src/main/java/com/google/android/exoplayer2/audio/AudioTrack.java
@@ -938,7 +938,7 @@ public final class AudioTrack {
    * audio session id has changed. Enabling tunneling requires platform API version 21 onwards.
    *
    * @param tunnelingAudioSessionId The audio session id to use.
-   * @throws IllegalStateException Thrown if enabling tunneling on platform API version < 21.
+   * @throws IllegalStateException Thrown if enabling tunneling on platform API version &lt; 21.
    */
   public void enableTunnelingV21(int tunnelingAudioSessionId) {
     Assertions.checkState(Util.SDK_INT >= 21);

--- a/library/src/main/java/com/google/android/exoplayer2/audio/DolbyPassthroughAudioTrack.java
+++ b/library/src/main/java/com/google/android/exoplayer2/audio/DolbyPassthroughAudioTrack.java
@@ -148,7 +148,7 @@ public final class DolbyPassthroughAudioTrack extends android.media.AudioTrack {
   /**
    * Play will block until previous messages to handler Thread
    * are executed.
-   * We need to serialize play, write, pause & release because otherwise,
+   * We need to serialize play, write, pause &amp; release because otherwise,
    * base audio track  will misbehave.
    */
   @Override
@@ -273,7 +273,7 @@ public final class DolbyPassthroughAudioTrack extends android.media.AudioTrack {
   /**
    * Release will block until previous messages to handler Thread
    * are executed.
-   * We need to serialize play, write, pause & release because otherwise,
+   * We need to serialize play, write, pause &amp; release because otherwise,
    * base audio track  will misbehave.
    */
   @Override

--- a/library/src/main/java/com/google/android/exoplayer2/drm/DefaultDrmSessionManager.java
+++ b/library/src/main/java/com/google/android/exoplayer2/drm/DefaultDrmSessionManager.java
@@ -277,17 +277,17 @@ public class DefaultDrmSessionManager<T extends ExoMediaCrypto> implements DrmSe
    * Sets the mode, which determines the role of sessions acquired from the instance. This must be
    * called before {@link #acquireSession(Looper, DrmInitData)} is called.
    *
-   * <p>By default, the mode is {@link #MODE_PLAYBACK} and a streaming license is requested when
+   * .By default, the mode is {@link #MODE_PLAYBACK} and a streaming license is requested when
    * required.
    *
-   * <p>{@code mode} must be one of these:
-   * <li>{@link #MODE_PLAYBACK}: If {@code offlineLicenseKeySetId} is null, a streaming license is
+   * .{@code mode} must be one of these:
+   * .{@link #MODE_PLAYBACK}: If {@code offlineLicenseKeySetId} is null, a streaming license is
    *     requested otherwise the offline license is restored.
-   * <li>{@link #MODE_QUERY}: {@code offlineLicenseKeySetId} can not be null. The offline license
+   * .{@link #MODE_QUERY}: {@code offlineLicenseKeySetId} can not be null. The offline license
    *     is restored.
-   * <li>{@link #MODE_DOWNLOAD}: If {@code offlineLicenseKeySetId} is null, an offline license is
+   * .{@link #MODE_DOWNLOAD}: If {@code offlineLicenseKeySetId} is null, an offline license is
    *     requested otherwise the offline license is renewed.
-   * <li>{@link #MODE_RELEASE}: {@code offlineLicenseKeySetId} can not be null. The offline license
+   * .{@link #MODE_RELEASE}: {@code offlineLicenseKeySetId} can not be null. The offline license
    *     is released.
    *
    * @param mode The mode to be set.

--- a/library/src/main/java/com/google/android/exoplayer2/util/Logger.java
+++ b/library/src/main/java/com/google/android/exoplayer2/util/Logger.java
@@ -32,7 +32,7 @@ public class Logger {
          */
         AudioVideoCommon,
         /**
-         *  Module that includes MediaCodecAudioTrackRenderer & AudioTrack
+         *  Module that includes MediaCodecAudioTrackRenderer &amp; AudioTrack
          */
         Audio,
         /**
@@ -40,7 +40,7 @@ public class Logger {
          */
         Video,
         /**
-         *  Module that includes MOD_VIDEO, MOD_AUDIO & MOD_AUDIO_VIDEO_COMMON
+         *  Module that includes MOD_VIDEO, MOD_AUDIO &amp; MOD_AUDIO_VIDEO_COMMON
          */
         AudioVideo,
 
@@ -83,7 +83,7 @@ public class Logger {
      *   Setting AudioVideo enables logging in both Audio and Video
      *   Setting Audio or Video enables logging in AudioVideoCommon
      * @param logLevel Log level for this module. One of the constants in
-     *    android.util.Log. i.e Log.ERROR, Log.WARNING, Log.INFO, Log.DEBUG & Log.VERBOSE
+     *    android.util.Log. i.e Log.ERROR, Log.WARNING, Log.INFO, Log.DEBUG &amp; Log.VERBOSE
      *    Info , error and warning logs are always printed.
      *    Setting to Log.INFO, Log.ERROR, Log.WARNING etc disables DEBUG and VERBOSE logs.
      *    Setting to Log.VERBOSE prints Debug and Verbose logs.


### PR DESCRIPTION
There is a slight inconvenience with using this repository - it fails to build on Jitpack. For example, see the build log for r2.2.0:
https://jitpack.io/com/github/amzn/exoplayer-amazon-port/7dfce153b4/build.log

Original source code, however, builds without any problem, see build log for r2.3.1:
https://jitpack.io/com/github/google/ExoPlayer/6577013/build.log

Please, consider this pull request as informative, since it resolves the "missing public artifact" issues (#2, #4 ) in quite a hacky way. If you know how to achieve this purpose more efficiently - please do that. We, developers, depend on a public artifact, and we are missing it very much.
