### PR TITLE
Fixed javadoc errors, which prevent jitpack.io build for r2.3.0 branch

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer2/audio/DolbyPassthroughAudioTrack.java
+++ b/library/src/main/java/com/google/android/exoplayer2/audio/DolbyPassthroughAudioTrack.java
@@ -148,7 +148,7 @@ public final class DolbyPassthroughAudioTrack extends android.media.AudioTrack {
   /**
    * Play will block until previous messages to handler Thread
    * are executed.
-   * We need to serialize play, write, pause & release because otherwise,
+   * We need to serialize play, write, pause &amp; release because otherwise,
    * base audio track  will misbehave.
    */
   @Override
@@ -273,7 +273,7 @@ public final class DolbyPassthroughAudioTrack extends android.media.AudioTrack {
   /**
    * Release will block until previous messages to handler Thread
    * are executed.
-   * We need to serialize play, write, pause & release because otherwise,
+   * We need to serialize play, write, pause &amp; release because otherwise,
    * base audio track  will misbehave.
    */
   @Override

--- a/library/src/main/java/com/google/android/exoplayer2/util/Logger.java
+++ b/library/src/main/java/com/google/android/exoplayer2/util/Logger.java
@@ -32,7 +32,7 @@ public class Logger {
          */
         AudioVideoCommon,
         /**
-         *  Module that includes MediaCodecAudioTrackRenderer & AudioTrack
+         *  Module that includes MediaCodecAudioTrackRenderer &amp; AudioTrack
          */
         Audio,
         /**
@@ -40,7 +40,7 @@ public class Logger {
          */
         Video,
         /**
-         *  Module that includes MOD_VIDEO, MOD_AUDIO & MOD_AUDIO_VIDEO_COMMON
+         *  Module that includes MOD_VIDEO, MOD_AUDIO &amp; MOD_AUDIO_VIDEO_COMMON
          */
         AudioVideo,
 
@@ -83,7 +83,7 @@ public class Logger {
      *   Setting AudioVideo enables logging in both Audio and Video
      *   Setting Audio or Video enables logging in AudioVideoCommon
      * @param logLevel Log level for this module. One of the constants in
-     *    android.util.Log. i.e Log.ERROR, Log.WARNING, Log.INFO, Log.DEBUG & Log.VERBOSE
+     *    android.util.Log. i.e Log.ERROR, Log.WARNING, Log.INFO, Log.DEBUG &amp; Log.VERBOSE
      *    Info , error and warning logs are always printed.
      *    Setting to Log.INFO, Log.ERROR, Log.WARNING etc disables DEBUG and VERBOSE logs.
      *    Setting to Log.VERBOSE prints Debug and Verbose logs.


### PR DESCRIPTION
Fixed javadoc lint errors in files DolbyPassthroughAudioTrack.java and Logger.java.

I bet I would not need to make this pull request if those two files could be linted before adding. If it is possible, please, adjust those files so that they don't generate build error next time. These two files perhaps were created before Lint became so strict. Now it's time to update them.

PS. One may validate the build-ability of this pull request here: https://jitpack.io/com/github/alex-schwartzman/exoplayer-amazon-port/20cf27c/build.log
