### PR TITLE
Publish to JitPack instead of jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.1'
-        classpath 'com.novoda:bintray-release:0.4.0'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }
     // Workaround for the following test coverage issue. Remove when fixed:
     // https://code.google.com/p/android/issues/detail?id=226070
@@ -45,11 +45,6 @@ allprojects {
         supportLibraryVersion = '25.3.1'
         dexmakerVersion = '1.2'
         mockitoVersion = '1.9.5'
-        releaseRepoName = getBintrayRepo()
-        releaseUserOrg = 'google'
-        releaseGroupId = 'com.google.android.exoplayer'
-        releaseVersion = 'r2.4.4'
-        releaseWebsite = 'https://github.com/google/ExoPlayer'
     }
     if (it.hasProperty('externalBuildDir')) {
         if (!new File(externalBuildDir).isAbsolute()) {
@@ -57,12 +52,6 @@ allprojects {
         }
         buildDir = "${externalBuildDir}/${project.name}"
     }
-}
-
-def getBintrayRepo() {
-    boolean publicRepo = hasProperty('publicRepo') &&
-        property('publicRepo').toBoolean()
-    return publicRepo ? 'exoplayer' : 'exoplayer-test'
 }
 
 apply from: 'javadoc_combined.gradle'

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,24 +1,2 @@
-// Copyright (C) 2017 The Android Open Source Project
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-apply plugin: 'bintray-release'
-
-publish {
-    artifactId = releaseArtifact
-    description = releaseDescription
-    repoName = releaseRepoName
-    userOrg = releaseUserOrg
-    groupId = releaseGroupId
-    version = releaseVersion
-    website = releaseWebsite
-}
+apply plugin: 'com.github.dcendents.android-maven'
+group="com.github.amzn"


### PR DESCRIPTION
Since there hasn't been any movement on #2 or #4, these changes automatically make builds available via jitpack.