### PR TITLE
End of Stream not handled in case of tunneling

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/audio/MediaCodecAudioRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/audio/MediaCodecAudioRenderer.java
@@ -55,6 +55,7 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
   private int channelCount;
   private long currentPositionUs;
   private boolean allowPositionDiscontinuity;
+  private boolean tunneling;
 
   private static final String TAG = MediaCodecAudioRenderer.class.getSimpleName();
   private final Logger log = new Logger(Logger.Module.Audio, TAG);
@@ -139,6 +140,11 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
     super(C.TRACK_TYPE_AUDIO, mediaCodecSelector, drmSessionManager, playClearSamplesWithoutKeys);
     audioTrack = new AudioTrack(audioCapabilities, audioProcessors, new AudioTrackListener());
     eventDispatcher = new EventDispatcher(eventHandler, eventListener);
+  }
+
+  @Override
+  protected boolean tunnelingEnabled() {
+    return tunneling;
   }
 
   @Override
@@ -307,8 +313,10 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
     int tunnelingAudioSessionId = getConfiguration().tunnelingAudioSessionId;
     if (tunnelingAudioSessionId != C.AUDIO_SESSION_ID_UNSET) {
       audioTrack.enableTunnelingV21(tunnelingAudioSessionId);
+      tunneling = true;
     } else {
       audioTrack.disableTunneling();
+      tunneling = false;
     }
   }
 

--- a/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
@@ -302,6 +302,15 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
       throws DecoderQueryException;
 
   /**
+   * Returns if tunneling is enabled.
+   *
+   * @return by default tunneling is disabled unless it's overriden by the renderer.
+   */
+  protected boolean tunnelingEnabled() {
+    return false;
+  }
+
+  /**
    * Returns a {@link MediaCodecInfo} for a given format.
    *
    * @param mediaCodecSelector The decoder selector.
@@ -981,6 +990,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
   @SuppressWarnings("deprecation")
   private boolean drainOutputBuffer(long positionUs, long elapsedRealtimeUs)
       throws ExoPlaybackException {
+
     if (log.allowVerbose()) {
       log.v("drainOutputBuffer: positionUs = " + positionUs + " elapsedRealtimeUs = " + elapsedRealtimeUs);
     }
@@ -1001,6 +1011,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
         outputIndex = codec.dequeueOutputBuffer(outputBufferInfo,
             getDequeueOutputBufferTimeoutUs());
       }
+
       if (outputIndex >= 0) {
         // We've dequeued a buffer.
         if (shouldSkipAdaptationWorkaroundOutputBuffer) {
@@ -1033,9 +1044,10 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
         processOutputBuffersChanged();
         return true;
       } else /* MediaCodec.INFO_TRY_AGAIN_LATER (-1) or unknown negative return value */ {
-        if (codecNeedsEosPropagationWorkaround && (inputStreamEnded
+        if ((codecNeedsEosPropagationWorkaround || tunnelingEnabled()) && (inputStreamEnded
             || codecReinitializationState == REINITIALIZATION_STATE_WAIT_END_OF_STREAM)) {
-          log.i("dequeueOutputBuffer: processEndOfStream will be called while codecNeedsEosPropagationWorkaround is set." );
+          log.i(
+              "dequeueOutputBuffer: processEndOfStream will be called while codecNeedsEosPropagationWorkaround is set.");
           processEndOfStream();
         }
         return false;

--- a/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
@@ -302,9 +302,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
       throws DecoderQueryException;
 
   /**
-   * Returns if tunneling is enabled.
-   *
-   * @return by default tunneling is disabled unless it's overriden by the renderer.
+   * By default tunneling is disabled unless it's overriden by the renderer.
    */
   protected boolean tunnelingEnabled() {
     return false;

--- a/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
@@ -990,7 +990,6 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
   @SuppressWarnings("deprecation")
   private boolean drainOutputBuffer(long positionUs, long elapsedRealtimeUs)
       throws ExoPlaybackException {
-
     if (log.allowVerbose()) {
       log.v("drainOutputBuffer: positionUs = " + positionUs + " elapsedRealtimeUs = " + elapsedRealtimeUs);
     }
@@ -1011,7 +1010,6 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
         outputIndex = codec.dequeueOutputBuffer(outputBufferInfo,
             getDequeueOutputBufferTimeoutUs());
       }
-
       if (outputIndex >= 0) {
         // We've dequeued a buffer.
         if (shouldSkipAdaptationWorkaroundOutputBuffer) {
@@ -1046,8 +1044,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
       } else /* MediaCodec.INFO_TRY_AGAIN_LATER (-1) or unknown negative return value */ {
         if ((codecNeedsEosPropagationWorkaround || tunnelingEnabled()) && (inputStreamEnded
             || codecReinitializationState == REINITIALIZATION_STATE_WAIT_END_OF_STREAM)) {
-          log.i(
-              "dequeueOutputBuffer: processEndOfStream will be called while codecNeedsEosPropagationWorkaround is set.");
+          log.i("dequeueOutputBuffer: processEndOfStream will be called while codecNeedsEosPropagationWorkaround is set.");
           processEndOfStream();
         }
         return false;

--- a/library/core/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java
@@ -860,7 +860,6 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer {
       boolean deviceNeedsAutoFrcWorkaround, String codecName, //AMZN_CHANGE_ONELINE
       int tunnelingAudioSessionId) {
     MediaFormat frameworkMediaFormat = format.getFrameworkMediaFormatV16();
-    Log.w(TAG, "max dim: " + codecMaxValues.width + "x" + codecMaxValues.height);
     // Set the maximum adaptive video dimensions.
     frameworkMediaFormat.setInteger(MediaFormat.KEY_MAX_WIDTH, codecMaxValues.width);
     frameworkMediaFormat.setInteger(MediaFormat.KEY_MAX_HEIGHT, codecMaxValues.height);

--- a/library/core/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java
@@ -194,6 +194,11 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer {
   }
 
   @Override
+  protected boolean tunnelingEnabled() {
+    return tunneling;
+  }
+
+  @Override
   protected int supportsFormat(MediaCodecSelector mediaCodecSelector, Format format)
       throws DecoderQueryException {
     String mimeType = format.sampleMimeType;
@@ -855,6 +860,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer {
       boolean deviceNeedsAutoFrcWorkaround, String codecName, //AMZN_CHANGE_ONELINE
       int tunnelingAudioSessionId) {
     MediaFormat frameworkMediaFormat = format.getFrameworkMediaFormatV16();
+    Log.w(TAG, "max dim: " + codecMaxValues.width + "x" + codecMaxValues.height);
     // Set the maximum adaptive video dimensions.
     frameworkMediaFormat.setInteger(MediaFormat.KEY_MAX_WIDTH, codecMaxValues.width);
     frameworkMediaFormat.setInteger(MediaFormat.KEY_MAX_HEIGHT, codecMaxValues.height);


### PR DESCRIPTION
In case of tunneling, the MediaCodecVideoRenderer does not use the software codec which leads it to getting always an outputIndex of -1.

In this case the renderer will only end if codecNeedsEosPropagationWorkaround is enabled, however for tunneling this is required for all devices